### PR TITLE
feat: added response_latency_ms metrics with status breakdown

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,14 +9,16 @@ use std::str::from_utf8;
 use std::sync::Arc;
 
 use axum::{http, middleware, Router, routing::get};
+use axum::body::HttpBody;
 use axum::extract::{Path, State};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use clap::{crate_version, Parser};
 use lazy_static::lazy_static;
 use maud::{DOCTYPE, html, Markup, PreEscaped};
-use prometheus::{self, Encoder, IntCounter, TextEncoder};
+use prometheus::{self, Encoder, Histogram, HistogramOpts, IntCounter, TextEncoder};
 use prometheus::proto::{Gauge, Metric, MetricFamily, MetricType};
+use prometheus::register_histogram;
 use prometheus::register_int_counter;
 use protobuf::RepeatedField;
 use rust_embed::RustEmbed;
@@ -81,6 +83,16 @@ lazy_static! {
     static ref START_TIME: std::time::Instant = std::time::Instant::now();
     static ref REQUESTS_RECEIVED: IntCounter =
         register_int_counter!("requests", "Number of http requests received").unwrap();
+    static ref RESPONSE_BYTES: IntCounter =
+        register_int_counter!("response_bytes", "Total number of bytes of responses sent").unwrap();
+    static ref RESPONSE_LATENCY_2XX: Histogram =
+        register_histogram!(HistogramOpts::new("response_latency_ms".to_string(), "Response latency in milliseconds".to_string()).const_label("status_family", "2xx")).unwrap();
+    static ref RESPONSE_LATENCY_3XX: Histogram =
+        register_histogram!(HistogramOpts::new("response_latency_ms".to_string(), "Response latency in milliseconds".to_string()).const_label("status_family", "3xx")).unwrap();
+    static ref RESPONSE_LATENCY_4XX: Histogram =
+        register_histogram!(HistogramOpts::new("response_latency_ms".to_string(), "Response latency in milliseconds".to_string()).const_label("status_family", "4xx")).unwrap();
+    static ref RESPONSE_LATENCY_5XX: Histogram =
+        register_histogram!(HistogramOpts::new("response_latency_ms".to_string(), "Response latency in milliseconds".to_string()).const_label("status_family", "5xx")).unwrap();
 }
 
 fn collect_posts() -> Vec<Post> {
@@ -624,8 +636,20 @@ async fn metricz() -> Response {
 }
 
 async fn metric_layer<B>(request: http::Request<B>, next: middleware::Next<B>) -> Response {
+    let start = std::time::Instant::now();
     REQUESTS_RECEIVED.inc();
     let response = next.run(request).await;
+    let elapsed = std::time::Instant::now().duration_since(start).as_millis() as f64;
+    if response.status().is_success() {
+        RESPONSE_LATENCY_2XX.observe(elapsed)
+    } else if response.status().is_redirection() {
+        RESPONSE_LATENCY_3XX.observe(elapsed)
+    } else if response.status().is_client_error() {
+        RESPONSE_LATENCY_4XX.observe(elapsed)
+    } else if response.status().is_server_error() {
+        RESPONSE_LATENCY_5XX.observe(elapsed)
+    }
+    RESPONSE_BYTES.inc_by(response.body().size_hint().lower());
     response
 }
 


### PR DESCRIPTION
Fixes: gh-10

```
# HELP requests Number of http requests received
# TYPE requests counter
requests 27
# HELP response_bytes Total number of bytes of responses sent
# TYPE response_bytes counter
response_bytes 30766
# HELP response_latency_ms Response latency in milliseconds
# TYPE response_latency_ms histogram
response_latency_ms_bucket{status_family="2xx",le="0.005"} 25
response_latency_ms_bucket{status_family="2xx",le="0.01"} 25
response_latency_ms_bucket{status_family="2xx",le="0.025"} 25
response_latency_ms_bucket{status_family="2xx",le="0.05"} 25
response_latency_ms_bucket{status_family="2xx",le="0.1"} 25
response_latency_ms_bucket{status_family="2xx",le="0.25"} 25
response_latency_ms_bucket{status_family="2xx",le="0.5"} 25
response_latency_ms_bucket{status_family="2xx",le="1"} 26
response_latency_ms_bucket{status_family="2xx",le="2.5"} 26
response_latency_ms_bucket{status_family="2xx",le="5"} 26
response_latency_ms_bucket{status_family="2xx",le="10"} 26
response_latency_ms_bucket{status_family="2xx",le="+Inf"} 26
response_latency_ms_sum{status_family="2xx"} 1
response_latency_ms_count{status_family="2xx"} 26
# HELP elapsed_millis the last unix timestamp from the container
# TYPE elapsed_millis gauge
elapsed_millis 17788
```